### PR TITLE
Validate non-English item metadata descriptions

### DIFF
--- a/server/lib/hypercat/hypercat.js
+++ b/server/lib/hypercat/hypercat.js
@@ -78,7 +78,7 @@ module.exports = (function() {
                                 // Loop through metadata properties
                                 for (j = 0; j < itemMetadata.length; j += 1) {
                                     prop = itemMetadata[j];
-                                    if (prop.rel === 'urn:X-hypercat:rels:hasDescription:en') {
+                                    if (prop.rel.startsWith('urn:X-hypercat:rels:hasDescription:')) {
                                         descriptionFound = true;
                                     }
 


### PR DESCRIPTION
This modification will allow descriptions with a rel ending in an ISO country code that is not "en" as PAS 4.4 implies. In other words, e.g. "urn:X-hypercat:rels:hasDescription:de" will be considered valid too.